### PR TITLE
Fixes to allow "all" isotopes

### DIFF
--- a/src/snf_simulations/cask.py
+++ b/src/snf_simulations/cask.py
@@ -31,6 +31,41 @@ DEFAULT_ISOTOPES = [
 ]
 
 
+def _filter_isotopes(isotopes: list[str], verbose: bool = False) -> list[str]:
+    """Filter a list of isotopes to only include relevant antineutrino spectra."""
+    filtered_isotopes = []
+    for isotope in isotopes:
+        # Isotopes that end in "m" or "n" are metastable states,
+        # which we'll just ignore for now.
+        if isotope.endswith("m") or isotope.endswith("n"):
+            if verbose:
+                print(f"Excluding metastable isotope: {isotope}")
+            continue
+
+        # Only select isotopes that have a B- decay mode,
+        # as these are the ones that will contribute to the antineutrino spectrum.
+        properties = get_isotope_properties(isotope)
+        if "B-" not in properties["decay_modes"]:
+            if verbose:
+                print(f"Excluding isotope without B- decay: {isotope}")
+            continue
+
+        # We also want to exclude isotopes that don't have any antineutrino spectrum
+        # data in the IAEA database.
+        try:
+            Spectrum.from_isotope(isotope)
+        except ValueError as err:
+            if "No antineutrino spectrum data found for isotope" in str(err):
+                if verbose:
+                    msg = f"Excluding isotope with empty spectrum data: {isotope}"
+                    print(msg)
+                continue
+
+        filtered_isotopes.append(isotope)
+
+    return filtered_isotopes
+
+
 class Cask:
     """Class representing a cask of spent nuclear fuel.
 
@@ -137,16 +172,25 @@ class Cask:
                 selected_isotopes = DEFAULT_ISOTOPES
             else:
                 selected_isotopes = cast(Collection[str], isotopes)
-            isotope_masses = {
-                isotope: mass
-                for isotope, mass in isotope_masses.items()
-                if isotope in selected_isotopes
-            }
+        else:
+            selected_isotopes = isotope_masses.keys()
+        selected_isotopes = _filter_isotopes(
+            list(selected_isotopes),
+            verbose=isotopes != "all",  # Only print if given a list
+        )
+        isotope_masses = {
+            isotope: mass
+            for isotope, mass in isotope_masses.items()
+            if isotope in selected_isotopes
+        }
+
+        # Extract filename if no name is given
         if name is None:
             if isinstance(filepath, Path):
                 name = filepath.stem
             elif filepath.endswith(".tbQ"):
                 name = filepath.rsplit("/", maxsplit=1)[-1].split(".", maxsplit=1)[0]
+
         return cls(
             isotope_masses=isotope_masses,
             initial_cooling_time=cooling_time,

--- a/src/snf_simulations/dashboard.py
+++ b/src/snf_simulations/dashboard.py
@@ -11,7 +11,7 @@ import plotly.graph_objects as go
 from shiny import App, Inputs, Outputs, Session, reactive, render, ui
 from shinywidgets import output_widget, render_widget
 
-from snf_simulations.cask import Cask
+from snf_simulations.cask import DEFAULT_ISOTOPES, Cask
 from snf_simulations.data import get_example_tbq_path
 from snf_simulations.physics import calculate_event_rate, calculate_flux_at_distance
 
@@ -24,6 +24,7 @@ class SimInputs(TypedDict):
     cask_mass: float
     n_casks: int
     cooling_times: list[float]
+    all_isotopes: bool
     detector_distance: float
 
 
@@ -55,6 +56,9 @@ app_ui = ui.page_fluid(
                 .form-group.shiny-input-container:first-of-type {
                 margin-top: -4px;
                 margin-bottom: -4px;
+            }
+            .form-group {
+                margin-bottom: 0 !important;
             }
             #tbq_file_progress {
                 height: auto;
@@ -137,6 +141,18 @@ app_ui = ui.page_fluid(
                 "tbq_file",
                 "Upload .tbQ file:",
                 accept=[".tbQ"],
+            ),
+            ui.tooltip(
+                ui.input_switch(
+                    "all_isotopes",
+                    "Include all isotopes",
+                    value=False,
+                ),
+                (
+                    f"By default only {len(DEFAULT_ISOTOPES)} isotopes are included. "
+                    "Only applicable if uploading a custom .tbQ file."
+                ),
+                placement="right",
             ),
             ui.input_numeric(
                 "cask_mass",
@@ -268,6 +284,7 @@ def server(input: Inputs, output: Outputs, session: Session) -> None:  # noqa: P
             "cask_mass": 10000.0,
             "n_casks": 1,
             "cooling_times": [0.5, 1.0, 5.0, 10.0],
+            "all_isotopes": False,
             "detector_distance": 40.0,
         }
     )
@@ -280,9 +297,19 @@ def server(input: Inputs, output: Outputs, session: Session) -> None:  # noqa: P
             filepath = params["filepath"]
             total_mass = float(params["cask_mass"]) * int(params["n_casks"])
             name = params["cask_name"]
+            if filepath == get_example_tbq_path():
+                # Example file only includes the default isotopes
+                isotopes = None
+            else:
+                isotopes = "all" if params["all_isotopes"] else None
 
             # Create the Cask instance
-            cask = Cask.from_tabqfile(filepath, total_mass=total_mass, name=name)
+            cask = Cask.from_tabqfile(
+                filepath,
+                total_mass=total_mass,
+                isotopes=isotopes,
+                name=name,
+            )
             return cask
 
         except Exception as e:
@@ -308,6 +335,7 @@ def server(input: Inputs, output: Outputs, session: Session) -> None:  # noqa: P
             cask_mass = float(input.cask_mass())
             n_casks = int(input.n_casks())
             cooling_times = [float(t) for t in input.cooling_times()]
+            all_isotopes = bool(input.all_isotopes())
             detector_distance = float(input.detector_distance())
 
             snapshot: SimInputs = {
@@ -317,6 +345,7 @@ def server(input: Inputs, output: Outputs, session: Session) -> None:  # noqa: P
                 "n_casks": n_casks,
                 "cooling_times": cooling_times,
                 "detector_distance": detector_distance,
+                "all_isotopes": all_isotopes,
             }
             sim_inputs.set(snapshot)
         except Exception as e:

--- a/src/snf_simulations/data/fispin.py
+++ b/src/snf_simulations/data/fispin.py
@@ -59,12 +59,19 @@ def load_tabqfile(filepath_or_contents: str | Path) -> dict[str, pd.DataFrame]:
         for data_line in lines[i + 2 :]:
             if data_line.startswith("TOTAL"):
                 break
+
             # Complication: the first few characters are the isotope,
             # which can contain spaces (e.g. "U 235").
             # We'll remove spaces from the first 12 characters before splitting.
+            # The FISPIN format also uses "A" as the atomic symbol
+            # for argon, not "Ar", so we replace that here.
             # We also format the isotope to be capitalised (e.g. "Sr90"),
             # by default the file has them in uppercase (e.g. "SR90").
-            isotope = data_line[0:12].capitalize().replace(" ", "")
+            isotope = data_line[0:12].capitalize()
+            if isotope[:2] == "A ":
+                isotope = "Ar" + isotope[2:]
+            isotope = isotope.replace(" ", "")
+
             data_line_new = f"{isotope:>12}{data_line[12:]}"
             data = data_line_new.strip().split()
             isotope_data.append(data)

--- a/src/snf_simulations/data/iaea.py
+++ b/src/snf_simulations/data/iaea.py
@@ -123,6 +123,10 @@ def _download_spectrum_data(isotope_name: str) -> str:
                 f"the cache as '{target_path}'."
             )
             raise RuntimeError(msg) from err
+        else:
+            msg = f"HTTP error {err.code} when downloading spectrum data for {nuclide}"
+            msg += f" from IAEA database: {err.reason}"
+            raise RuntimeError(msg) from err
     except Exception as err:
         msg = f"Error downloading spectrum data for {nuclide} from IAEA database: {err}"
         raise RuntimeError(msg) from err

--- a/src/snf_simulations/data/iaea.py
+++ b/src/snf_simulations/data/iaea.py
@@ -137,7 +137,9 @@ def _download_spectrum_data(isotope_name: str, timeout: float = 20.0) -> str:
 
     # Some nuclides (e.g. Ru106) have duplicate rows in the IAEA database.
     # These break creating histograms, so remove exact duplicates before caching.
-    data = data.drop_duplicates()
+    # Some (Ra228) even have duplicate energy lines but different (rounded) fluxes!
+    # So we specify based only on the energy column.
+    data = data.drop_duplicates(subset=["bin_en"], keep="first")
 
     filename = _get_cache_file(nuclide)
     if not filename.is_file():

--- a/src/snf_simulations/data/iaea.py
+++ b/src/snf_simulations/data/iaea.py
@@ -88,12 +88,13 @@ def _parse_nuclide(isotope_name: str) -> str:
     return f"{mass_number}{element.lower()}"
 
 
-def _download_spectrum_data(isotope_name: str) -> str:
+def _download_spectrum_data(isotope_name: str, timeout: float = 20.0) -> str:
     """Download the antineutrino spectrum for a given nuclide from the IAEA database.
 
     Args:
         isotope_name: Name of the isotope to download data for.
             Format should be 'ElementMass' (e.g. Ru106) or 'MassElement' (e.g. 106Ru).
+        timeout: Timeout for the HTTP request in seconds.
 
     Returns:
         Path to the downloaded spectrum data file in the cache.
@@ -110,7 +111,8 @@ def _download_spectrum_data(isotope_name: str) -> str:
     # which should bypass Cloudflare checks.
     req.add_header("User-Agent", "Livechart/1.0")
     try:
-        content = urllib.request.urlopen(req, timeout=5).read().decode("utf-8")  # noqa: S310
+        request = urllib.request.urlopen(req, timeout=timeout)  # noqa: S310
+        content = request.read().decode("utf-8")
     except urllib.error.HTTPError as err:
         body = ""
         if err.fp is not None:
@@ -188,5 +190,6 @@ def get_antineutrino_spectrum(isotope_name: str) -> np.ndarray:
     nuclide = _parse_nuclide(isotope_name)
     cache_file = _get_cache_file(nuclide)
     if not cache_file.is_file() and not _copy_packaged_spectrum_to_cache(isotope_name):
+        print(f"Downloading spectrum data for {nuclide} from IAEA database...")
         _download_spectrum_data(nuclide)
     return _load_spectrum_file(nuclide)

--- a/src/snf_simulations/data/mendeleev.py
+++ b/src/snf_simulations/data/mendeleev.py
@@ -1,43 +1,62 @@
 """Module for loading isotope data from the mendeleev package."""
 
 from functools import cache
+from typing import TypedDict
 
+import numpy as np
 from mendeleev import isotope
 
 from .utils import _UNITS_TO_SECONDS, _parse_isotope
 
 
+class IsotopeProperties(TypedDict):
+    """Class to represent the properties of an isotope."""
+
+    molar_mass: float
+    half_life: float
+    decay_modes: list[str]
+
+
 @cache
-def _get_isotope_properties_cached(isotope_name: str) -> tuple[float, float]:
+def _get_isotope_properties_cached(isotope_name: str) -> IsotopeProperties:
     """Return cached isotope properties loaded from mendeleev."""
     element, mass_number = _parse_isotope(isotope_name)
     mendeleev_isotope = isotope(element, mass_number)
 
     molar_mass = float(mendeleev_isotope.mass)  # ty: ignore
-    half_life = float(mendeleev_isotope.half_life)  # ty: ignore
-    unit = str(mendeleev_isotope.half_life_unit)
-    seconds_per_unit = _UNITS_TO_SECONDS.get(unit)
-    if seconds_per_unit is None:
-        msg = f"Unsupported half-life unit for isotope {isotope_name}: {unit}. "
-        msg += "Supported units are: "
-        msg += ", ".join(sorted(_UNITS_TO_SECONDS))
-        raise ValueError(msg)
-    half_life_years = half_life * seconds_per_unit / _UNITS_TO_SECONDS["year"]
+    if mendeleev_isotope.half_life is not None:
+        half_life = float(mendeleev_isotope.half_life)  # ty: ignore
+        unit = str(mendeleev_isotope.half_life_unit)
+        seconds_per_unit = _UNITS_TO_SECONDS.get(unit)
+        if seconds_per_unit is None:
+            msg = f"Unsupported half-life unit for isotope {isotope_name}: {unit}. "
+            msg += "Supported units are: "
+            msg += ", ".join(sorted(_UNITS_TO_SECONDS))
+            raise ValueError(msg)
+        half_life_years = half_life * seconds_per_unit / _UNITS_TO_SECONDS["year"]
+    else:
+        half_life_years = np.inf
+    decay_modes = [d.mode for d in mendeleev_isotope.decay_modes]
 
-    return molar_mass, half_life_years
+    return IsotopeProperties(
+        molar_mass=molar_mass, half_life=half_life_years, decay_modes=decay_modes
+    )
 
 
-def get_isotope_properties(isotope_name: str) -> dict[str, float]:
-    """Get the mass and half-life for the given isotope using the mendeleev package.
+def get_isotope_properties(isotope_name: str) -> IsotopeProperties:
+    """Get the mass, half-life and decay modes for the given isotope.
+
+    Uses data from the mendeleev package.
 
     Args:
         isotope_name: Name of the isotope.
             Format should be 'ElementMass' (e.g. Ru106) or 'MassElement' (e.g. 106Ru).
 
     Returns:
-        Dictionary containing the molar mass (in g/mol) and half-life (in years)
-        of the isotope.
+        Dictionary containing:
+        - the molar mass of the isotope (in g/mol)
+        - the half-life of the isotope (in years)
+        - the decay modes of the isotope (as a list of strings)
 
     """
-    molar_mass, half_life_years = _get_isotope_properties_cached(isotope_name)
-    return {"molar_mass": molar_mass, "half_life": half_life_years}
+    return _get_isotope_properties_cached(isotope_name)

--- a/src/snf_simulations/spec.py
+++ b/src/snf_simulations/spec.py
@@ -97,11 +97,15 @@ class Spectrum:
         """Create a Spectrum object from an isotope name."""
         # The IAEA data files give equal arrays of energy, flux, and uncertainty.
         data = get_antineutrino_spectrum(name)
-        energy_points, flux_points, error_points = data[:, 0], data[:, 1], data[:, 2]
+        if len(data) == 0:
+            # The file has been downloaded, but it is empty.
+            msg = f"No antineutrino spectrum data found for isotope {name}"
+            raise ValueError(msg)
 
         # Histogram representation requires N+1 edges for N bins.
         # The last energy point is used as the upper edge of the final bin,
         # so the last flux/error value is discarded.
+        energy_points, flux_points, error_points = data[:, 0], data[:, 1], data[:, 2]
         energy = energy_points
         flux = flux_points[:-1]
         errors = error_points[:-1]

--- a/tests/test_cask.py
+++ b/tests/test_cask.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from snf_simulations.cask import Cask
+from snf_simulations.cask import Cask, _filter_isotopes
 from snf_simulations.data import get_example_tbq_path, get_isotope_properties
 from snf_simulations.spec import Spectrum
 
@@ -230,3 +230,49 @@ def test_cask_from_example_tbq() -> None:
     cask = Cask.from_tabqfile(example_path)
     assert cask is not None
     assert len(cask.isotopes) > 0
+
+
+def test_filter_isotopes(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Test _filter_isotopes logic for all filter cases."""
+    props = {
+        "Sr90": {"decay_modes": ["B-"]},
+        "Cs137": {"decay_modes": ["B-"]},
+        "Y90m": {"decay_modes": ["B-"]},  # Metastable
+        "Am242": {"decay_modes": ["EC"]},  # No B-
+        "Xe135": {"decay_modes": ["B-"]},  # No spectrum
+    }
+
+    def fake_get_isotope_properties(isotope: str) -> dict:
+        return props[isotope]
+
+    monkeypatch.setattr(
+        "snf_simulations.cask.get_isotope_properties", fake_get_isotope_properties
+    )
+
+    def fake_from_isotope(isotope: str) -> str:
+        if isotope == "Xe135":
+            raise ValueError("No antineutrino spectrum data found for isotope Xe135")
+        return f"Spectrum({isotope})"
+
+    monkeypatch.setattr(
+        "snf_simulations.cask.Spectrum.from_isotope", staticmethod(fake_from_isotope)
+    )
+
+    isotopes = ["Sr90", "Cs137", "Am242", "Y90m", "Xe135"]
+    filtered = _filter_isotopes(isotopes)
+    assert set(filtered) == {"Sr90", "Cs137"}
+
+    # Check that the expected verbose messages were printed
+    _filter_isotopes(isotopes, verbose=True)
+    out = capsys.readouterr().out
+    assert "Excluding metastable isotope: Y90m" in out, (
+        "Should print message about excluding metastable isotope"
+    )
+    assert "Excluding isotope without B- decay: Am242" in out, (
+        "Should print message about excluding isotope with no B- decay"
+    )
+    assert "Excluding isotope with empty spectrum data: Xe135" in out, (
+        "Should print message about excluding isotope with empty spectrum data"
+    )

--- a/tests/test_data_fispin.py
+++ b/tests/test_data_fispin.py
@@ -69,6 +69,20 @@ def test_load_tabqfile_from_string() -> None:
     assert df["GRAMS"].tolist() == pytest.approx([3.0, 3.0])
 
 
+def test_load_tabqfile_argon() -> None:
+    """Test loading .tbQ file that uses A for argon."""
+    content = (
+        "*** TIME    1.200E+01 HOURS\n"
+        "ALL-NUC      GRAMS\n"
+        "A  38        3.0\n"
+        "TOTAL        3.0\n"
+    )
+    time_dfs = load_tabqfile(content)
+
+    df = time_dfs["1.200E+01 HOURS"]
+    assert df["ALL-NUC"].tolist() == ["Ar38"]
+
+
 def test_load_tabqfile_invalid_path() -> None:
     """Test that loading from an invalid file path raises FileNotFoundError."""
     with pytest.raises(FileNotFoundError):

--- a/tests/test_data_iaea.py
+++ b/tests/test_data_iaea.py
@@ -175,6 +175,28 @@ def test_download_spectrum_data_wraps_network_errors(
         _download_spectrum_data("Ru106")
 
 
+def test_download_spectrum_data_reports_http_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test Cloudflare 403 responses are reported with a clear message."""
+    monkeypatch.setenv("SNF_SIMULATIONS_CACHE_DIR", str(tmp_path))
+
+    def _raise_error(request: object, timeout: int = 5) -> object:
+        del request, timeout
+        raise urllib.error.HTTPError(
+            url="https://nds.iaea.org/relnsd/v1/data",
+            code=403,
+            msg="Forbidden",
+            hdrs=None,  # type: ignore
+            fp=BytesIO(),
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", _raise_error)
+
+    with pytest.raises(RuntimeError, match=r"HTTP error"):
+        _download_spectrum_data("Ru106")
+
+
 def test_download_spectrum_data_reports_cloudflare_block(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_data_mendeleev.py
+++ b/tests/test_data_mendeleev.py
@@ -124,6 +124,7 @@ def test_get_isotope_properties_cache(
         mass = 90.0
         half_life = 100.0
         half_life_unit = "year"
+        decay_modes = [type("DecayMode", (), {"mode": "B-"})()]
 
     def _mock_isotope(*_: object) -> _MockIsotope:
         # By using a nonlocal variable we can check how many times this

--- a/tests/test_data_mendeleev.py
+++ b/tests/test_data_mendeleev.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Iterator
 
+import numpy as np
 import pytest
 
 from snf_simulations.data.mendeleev import (
@@ -31,6 +32,7 @@ def test_get_isotope_properties(
         mass = 90.0
         half_life = 100.0
         half_life_unit = "year"
+        decay_modes = [type("DecayMode", (), {"mode": "B-"})()]
 
     monkeypatch.setattr(
         "snf_simulations.data.mendeleev.isotope", lambda *_: _MockIsotope()
@@ -39,6 +41,7 @@ def test_get_isotope_properties(
     isotope_properties = get_isotope_properties("Y90")
     assert isotope_properties["molar_mass"] == 90.0, "Molar mass should be 90 g/mol"
     assert isotope_properties["half_life"] == 100.0, "Half life should be 100 years"
+    assert isotope_properties["decay_modes"] == ["B-"], "Decay modes should be ['B-']"
 
 
 def test_get_isotope_properties_real() -> None:
@@ -52,6 +55,21 @@ def test_get_isotope_properties_real() -> None:
     assert isotope_properties["half_life"] == pytest.approx(0.0073, rel=1e-3), (
         "Half life of Y90 should be approximately 0.0073 years"
     )
+    assert isotope_properties["decay_modes"] == ["B-"], (
+        "Decay modes of Y90 should be ['B-']"
+    )
+
+    # Also test an isotope with a stable half-life to check that np.inf is returned
+    isotope_properties = get_isotope_properties("H1")
+    assert isotope_properties["molar_mass"] == pytest.approx(1.00784, rel=1e-3), (
+        "Molar mass of H1 should be approximately 1.00784 g/mol"
+    )
+    assert isotope_properties["half_life"] == np.inf, (
+        "Half life of stable isotope should be np.inf"
+    )
+    assert isotope_properties["decay_modes"] == [], (
+        "Decay modes of stable isotope should be empty"
+    )
 
 
 def test_get_isotope_properties_converts_to_years(
@@ -63,6 +81,7 @@ def test_get_isotope_properties_converts_to_years(
         mass = 90.0
         half_life = 24.0
         half_life_unit = "hour"
+        decay_modes = [type("DecayMode", (), {"mode": "B-"})()]
 
     monkeypatch.setattr(
         "snf_simulations.data.mendeleev.isotope", lambda *_: _MockIsotope()
@@ -85,6 +104,7 @@ def test_get_isotope_properties_unsupported_unit(
         mass = 1.0
         half_life = 1.0
         half_life_unit = "fortnight"
+        decay_modes = [type("DecayMode", (), {"mode": "B-"})()]
 
     monkeypatch.setattr(
         "snf_simulations.data.mendeleev.isotope", lambda *_: _MockIsotope()

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -137,6 +137,20 @@ def test_from_isotope(isotope: str) -> None:
     )
 
 
+def test_from_isotope_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that Spectrum.from_isotope raises with empty spectrum data."""
+    mock_data = np.array([])
+    monkeypatch.setattr(
+        "snf_simulations.spec.get_antineutrino_spectrum",
+        lambda *_: mock_data,
+    )
+
+    with pytest.raises(
+        ValueError, match="No antineutrino spectrum data found for isotope Sr90"
+    ):
+        Spectrum.from_isotope("Sr90")
+
+
 @pytest.mark.parametrize("width", [0.1, 1.0, 2.0])
 def test_equalise(width: float) -> None:
     """Test Spectrum equalisation over the energy range for given bin width."""


### PR DESCRIPTION
This PR fixes several errors allowing you to select all isotopes from a .tbQ file (`Cask.from_tbqfile(... isotopes="all")`).

First, fix #40 by allowing half-lives of "None", and also filtering out isotopes with empty antineutrino spectrum files. Also fixes #43.

In fact there's a new filter function in `cask.py`, which also removes isotopes with out B- decays (from #36, although doesn't yet look at the decay chains) and metastable isomers (#38).
https://github.com/ekneale/SNF-simulations/blob/ecb329c8b8f865c440bd494cff7d006be8170097/src/snf_simulations/cask.py#L34-L66

Then I've also added an "Include all isotopes" toggle to the dashboard, which can be enabled when loading a .tbQ file (by default it sticks to the default 16).

<img width="1862" height="529" alt="all-default" src="https://github.com/user-attachments/assets/c7ac3ed6-5476-458b-b9d9-eeb33e6a6dd4" />
<img width="1862" height="529" alt="all-all" src="https://github.com/user-attachments/assets/ce50baa7-d865-465c-b358-6e3a7e74ed4b" />

Note: this will be slow the first time triggered, as it will have to download hundreds of data files from the IAEA. Subsequent runs will be quicker, although the first time a cask is created it takes a few seconds to cache the isotope properties, but after that it's reasonably fast. Also displaying the plot with all the individual isotopes can also be quite slow to update, since it's plotting hundreds of lines!